### PR TITLE
[#100] Added Docker image with multi-arch CI build, test, and Docker Hub publish.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.artifacts
+.build
+.circleci
+.claude
+.git
+.github
+.idea
+.logs
+tests
+vendor
+vendor-bin

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,41 @@
+name: Release Docker
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  push-release-to-registry:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: drevops/git-artifact
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   push-release-to-registry:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   push-release-to-registry:
     runs-on: ubuntu-latest
@@ -12,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -9,6 +9,9 @@ on:
       - main
       - 'feature/**'
 
+permissions:
+  contents: read
+
 jobs:
   test-docker:
     runs-on: ubuntu-latest
@@ -16,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
@@ -69,6 +74,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,0 +1,98 @@
+name: Test Docker
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - 'feature/**'
+
+jobs:
+  test-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+
+      - name: Build Docker image
+        run: docker build -t "drevops/git-artifact:test" .
+
+      - name: Test that the image packages and pushes an artifact
+        run: |
+          set -ex
+
+          src="${RUNNER_TEMP}/src"
+          dst="${RUNNER_TEMP}/dst.git"
+
+          # Prepare a source repository with a tracked file.
+          mkdir -p "${src}"
+          git -C "${src}" init -b main
+          git -C "${src}" config user.name "Test"
+          git -C "${src}" config user.email "test@example.com"
+          echo "artifact content" > "${src}/file.txt"
+          git -C "${src}" add -A
+          git -C "${src}" commit -m "Initial commit"
+
+          # Prepare a bare destination repository to receive the artifact.
+          git init --bare -b main "${dst}"
+
+          # Package and push the artifact from inside the container. The source
+          # is mounted at the WORKDIR and the destination is mounted as a local
+          # remote. The commit identity is supplied via the environment (the
+          # image trusts mounted repositories via a baked-in safe.directory).
+          docker run --rm \
+            -e GIT_AUTHOR_NAME="Test" \
+            -e GIT_AUTHOR_EMAIL="test@example.com" \
+            -e GIT_COMMITTER_NAME="Test" \
+            -e GIT_COMMITTER_EMAIL="test@example.com" \
+            -v "${src}":/app \
+            -v "${dst}":/dst.git \
+            drevops/git-artifact:test \
+            /dst.git --branch=artifact --mode=force-push -vvv
+
+          # Assert the file landed on the destination branch.
+          git -C "${dst}" show artifact:file.txt | grep -q "artifact content"
+
+  push-canary-to-registry:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    needs:
+      - test-docker
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: drevops/git-artifact
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          push: true
+          tags: drevops/git-artifact:canary
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-docker:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# The image operates on a repository bind-mounted from the host, which is owned
-# by an arbitrary host user while the container runs as root, so git must be
-# told to trust it regardless of ownership.
-RUN git config --system --add safe.directory '*'
+# The source repository is bind-mounted at the WORKDIR from the host, so it is
+# owned by an arbitrary host user while the container runs as root; trust that
+# mount point so git does not reject it for dubious ownership.
+RUN git config --system --add safe.directory /app
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,12 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# The source repository is bind-mounted at the WORKDIR from the host, so it is
-# owned by an arbitrary host user while the container runs as root; trust that
-# mount point so git does not reject it for dubious ownership.
-RUN git config --system --add safe.directory /app
+# The container operates on repositories bind-mounted from the host at runtime -
+# a source and a destination whose paths are chosen by the caller and unknown at
+# build time - while running as root. Trust all directories so git does not
+# reject these host-owned mounts for dubious ownership; the container is
+# single-purpose and ephemeral, so the wildcard is an acceptable trust boundary.
+RUN git config --system --add safe.directory '*'
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+FROM php:8.5-cli@sha256:1954ff5cd21f222c992b79d25e403b2600cec829678d5bb7076883f3a44c0d6e AS builder
+
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y libzip-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-install zip
+
+# Install composer.
+# @see https://getcomposer.org/download
+# renovate: datasource=github-releases depName=composer/composer extractVersion=^(?<version>.*)$
+ENV COMPOSER_ALLOW_SUPERUSER=1
+# hadolint ignore=DL4006
+RUN version=2.8.10 && \
+    curl -sS https://getcomposer.org/download/${version}/composer.phar.sha256sum | awk '{ print $1, "composer.phar" }' > composer.phar.sha256sum && \
+    curl -sS -o composer.phar https://getcomposer.org/download/${version}/composer.phar && \
+    sha256sum -c composer.phar.sha256sum && \
+    chmod +x composer.phar && \
+    mv composer.phar /usr/local/bin/composer && \
+    rm composer.phar.sha256sum && \
+    composer --version && \
+    composer clear-cache
+
+WORKDIR /app
+
+COPY composer.json composer.lock /app/
+
+RUN COMPOSER_MEMORY_LIMIT=-1 composer install -n --ansi --prefer-dist --optimize-autoloader
+
+COPY . /app
+
+RUN composer build
+
+FROM php:8.5-cli@sha256:1954ff5cd21f222c992b79d25e403b2600cec829678d5bb7076883f3a44c0d6e
+
+# git is required because the tool shells out to the git binary; openssh-client
+# enables pushing to SSH remotes such as git@github.com:org/repo.git.
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y git openssh-client && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# The image operates on a repository bind-mounted from the host, which is owned
+# by an arbitrary host user while the container runs as root, so git must be
+# told to trust it regardless of ownership.
+RUN git config --system --add safe.directory '*'
+
+WORKDIR /app
+
+COPY --from=builder /app/.build/git-artifact /usr/local/bin/git-artifact
+
+RUN chmod +x /usr/local/bin/git-artifact
+
+ENTRYPOINT ["/usr/local/bin/git-artifact"]

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/drevops/git-artifact)
 [![codecov](https://codecov.io/gh/drevops/git-artifact/branch/main/graph/badge.svg?token=QNBXCIBK5J)](https://codecov.io/gh/drevops/git-artifact)
 [![Total Downloads](https://poser.pugx.org/drevops/behat-screenshot/downloads)](https://packagist.org/packages/drevops/git-artifact)
+[![Docker Pulls](https://img.shields.io/docker/pulls/drevops/git-artifact.svg)](https://hub.docker.com/r/drevops/git-artifact)
 ![LICENSE](https://img.shields.io/github/license/drevops/git-artifact)
 ![Renovate](https://img.shields.io/badge/renovate-enabled-green?logo=renovatebot)
 
 [![Test PHP](https://github.com/drevops/git-artifact/actions/workflows/test-php.yml/badge.svg)](https://github.com/drevops/git-artifact/actions/workflows/test-php.yml)
+[![Test Docker](https://github.com/drevops/git-artifact/actions/workflows/test-docker.yml/badge.svg)](https://github.com/drevops/git-artifact/actions/workflows/test-docker.yml)
 [![CircleCI](https://circleci.com/gh/drevops/git-artifact.svg?style=shield)](https://circleci.com/gh/drevops/git-artifact)
 
 [![Vortex Ecosystem](https://img.shields.io/badge/%F0%9F%8C%80-Vortex%20Ecosystem-2C5A68?style=for-the-badge&labelColor=65ACBC)](https://github.com/drevops/vortex)
@@ -172,6 +174,33 @@ This tool is intended to be used as a standalone binary. You will need to
 have PHP installed on your system to run the binary.
 
 Download the latest release from the [GitHub releases page](https://github.com/drevops/git-artifact/releases/latest).
+
+### As a Docker container
+
+The tool is also published as a multi-architecture (`linux/amd64`, `linux/arm64`) Docker image at [`drevops/git-artifact`](https://hub.docker.com/r/drevops/git-artifact), with `git` and an SSH client bundled in - no local PHP required. Mount your source repository at `/app` and pass the same arguments you would pass to the binary:
+
+```shell
+docker run --rm \
+  -v "${PWD}":/app \
+  -e GIT_AUTHOR_NAME="Deployer" -e GIT_AUTHOR_EMAIL="deployer@example.com" \
+  -e GIT_COMMITTER_NAME="Deployer" -e GIT_COMMITTER_EMAIL="deployer@example.com" \
+  drevops/git-artifact \
+  git@github.com:yourorg/your-repo-destination.git --branch=main
+```
+
+The `GIT_AUTHOR_*` and `GIT_COMMITTER_*` variables set the identity for the deployment commit. To push to an SSH remote, also mount your SSH credentials read-only:
+
+```shell
+docker run --rm \
+  -v "${PWD}":/app \
+  -v "${HOME}/.ssh":/root/.ssh:ro \
+  -e GIT_AUTHOR_NAME="Deployer" -e GIT_AUTHOR_EMAIL="deployer@example.com" \
+  -e GIT_COMMITTER_NAME="Deployer" -e GIT_COMMITTER_EMAIL="deployer@example.com" \
+  drevops/git-artifact \
+  git@github.com:yourorg/your-repo-destination.git --branch=main
+```
+
+Use the `drevops/git-artifact:canary` tag to test the latest unreleased changes from the `main` branch.
 
 ### As a Composer dependency
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/drevops/git-artifact)
 [![codecov](https://codecov.io/gh/drevops/git-artifact/branch/main/graph/badge.svg?token=QNBXCIBK5J)](https://codecov.io/gh/drevops/git-artifact)
 [![Total Downloads](https://poser.pugx.org/drevops/behat-screenshot/downloads)](https://packagist.org/packages/drevops/git-artifact)
-[![Docker Pulls](https://img.shields.io/docker/pulls/drevops/git-artifact.svg)](https://hub.docker.com/r/drevops/git-artifact)
+[![Docker Pulls](https://img.shields.io/docker/pulls/drevops/git-artifact?logo=docker)](https://hub.docker.com/r/drevops/git-artifact)
+![amd64](https://img.shields.io/badge/arch-linux%2Famd64-brightgreen)
+![arm64](https://img.shields.io/badge/arch-linux%2Farm64-brightgreen)
 ![LICENSE](https://img.shields.io/github/license/drevops/git-artifact)
 ![Renovate](https://img.shields.io/badge/renovate-enabled-green?logo=renovatebot)
 
@@ -200,7 +202,15 @@ docker run --rm \
   git@github.com:yourorg/your-repo-destination.git --branch=main
 ```
 
-Use the `drevops/git-artifact:canary` tag to test the latest unreleased changes from the `main` branch.
+#### Image tags
+
+Cross-platform (`linux/amd64`, `linux/arm64`) images are built by GitHub Actions and pushed to [Docker Hub](https://hub.docker.com/r/drevops/git-artifact):
+
+- `<version>` (e.g. `1.2.3`) - published when a release tag is created on GitHub.
+- `latest` - published when a release tag is created on GitHub.
+- `canary` - published on every push to the `main` branch (latest unreleased changes).
+
+Pin to a specific `<version>` tag for reproducible deployments and use `canary` only to try out unreleased changes.
 
 ### As a Composer dependency
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ docker run --rm \
   -e GIT_AUTHOR_NAME="Deployer" -e GIT_AUTHOR_EMAIL="deployer@example.com" \
   -e GIT_COMMITTER_NAME="Deployer" -e GIT_COMMITTER_EMAIL="deployer@example.com" \
   drevops/git-artifact \
-  git@github.com:yourorg/your-repo-destination.git --branch=main
+  https://github.com/yourorg/your-repo-destination.git --branch=main
 ```
 
 The `GIT_AUTHOR_*` and `GIT_COMMITTER_*` variables set the identity for the deployment commit. To push to an SSH remote, also mount your SSH credentials read-only:


### PR DESCRIPTION
Closes #100

## Summary

Adds a multi-architecture Docker image for `git-artifact` so the tool can be used without a local PHP installation. The image is built in a multi-stage `Dockerfile`, tested end-to-end in CI on every PR and push to `main`, published as `drevops/git-artifact:canary` on `main` pushes, and released to Docker Hub as versioned tags (plus `latest`) on git tag pushes.

## Changes

**`Dockerfile`** - Multi-stage build: a `builder` stage based on `php:8.5-cli` (digest-pinned) installs Composer and runs `composer build` to produce the Box PHAR; the runtime stage copies only the PHAR, installs `git` and `openssh-client`, bakes in `git config --system --add safe.directory '*'` to trust the host-mounted source and destination repositories, and sets the PHAR as the `ENTRYPOINT`.

**`.dockerignore`** - Excludes `.git`, `vendor`, `tests`, and other non-essential paths from the build context to keep the image build fast and prevent the host `vendor/` from leaking into the builder stage.

**`.github/workflows/test-docker.yml`** - Runs on PRs and `main` pushes: lints the `Dockerfile` with hadolint, builds the image, then runs a functional test that mounts a real source repo and a bare destination repo and asserts the artifact was pushed to the destination branch. A `push-canary-to-registry` job (gated on `main` push, needs the test job) publishes `drevops/git-artifact:canary` as a multi-arch image (`linux/amd64`, `linux/arm64`). Both jobs use `persist-credentials: false`, least-privilege `permissions: contents: read`, and concurrency control.

**`.github/workflows/release-docker.yml`** - Triggers on tag pushes: multi-arch build and push to Docker Hub (`drevops/git-artifact`) using `docker/build-push-action` with tags and labels derived from `docker/metadata-action`. Authenticates via `DOCKER_USER` / `DOCKER_PASS` repo secrets with `persist-credentials: false` and `permissions: contents: read`.

**`README.md`** - Adds Test Docker, Docker Pulls, and architecture (`amd64`/`arm64`) badges, plus an "As a Docker container" installation section with HTTPS and SSH usage examples and an "Image tags" subsection documenting the `canary`, `latest`, and versioned tags and how each is published.

## Before / After

```
Before:
  Distribution: PHAR binary (download from GitHub Releases)
               Composer global install
               Composer project dependency

After:
  Distribution: PHAR binary (download from GitHub Releases)
               Composer global install
               Composer project dependency
               Docker image: drevops/git-artifact (linux/amd64 + linux/arm64)
                 - :canary  → published on every main push
                 - :latest  → published on every git tag release
                 - :<tag>   → published on every git tag release
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Docker container for running `git-artifact`, with multi-architecture (amd64/arm64) builds and a ready-to-use entrypoint.
  * Added Docker CI that lint-checks the Dockerfile, builds the container, and verifies it produces the expected artifact output; on success, publishes a canary image.
  * Added a Docker release workflow that builds and pushes images for tagged releases.
* **Documentation**
  * Updated README with Docker badges and a new “As a Docker container” setup guide, including mount/SSH guidance and tag usage.
* **Chores**
  * Improved Docker build context by excluding additional development and build directories/files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
