### PR TITLE
[#23] Added '--cleanup-stale' option to prune stale remote branches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ In `branch` mode the _destination_ repository accumulates a new branch for every
 deployment. Enable `--cleanup-stale` to remove old ones automatically after a
 successful push:
 
-```
+```shell
 ./git-artifact git@github.com:yourorg/your-repo-destination.git \
   --mode=branch \
   --branch="deployment/[tags:.]" \

--- a/README.md
+++ b/README.md
@@ -168,6 +168,31 @@ repository would create a branch `deployment/1.2.3` in the destination
 repository. The addition of the new tags would create new unique branches in the
 destination repository.
 
+#### Cleanup of stale branches
+
+In `branch` mode the _destination_ repository accumulates a new branch for every
+deployment. Enable `--cleanup-stale` to remove old ones automatically after a
+successful push:
+
+```
+./git-artifact git@github.com:yourorg/your-repo-destination.git \
+  --mode=branch \
+  --branch="deployment/[tags:.]" \
+  --cleanup-stale \
+  --cleanup-pattern="deployment/*" \
+  --cleanup-age=3
+```
+
+Any branch in the _destination_ repository that matches `--cleanup-pattern` and
+whose last commit is older than `--cleanup-age` days is deleted. The branch that
+was just pushed and the _destination_ repository's default branch are never
+deleted. `--cleanup-pattern` is required - it is the only way to identify the
+branches created by your deployments - and is matched as a shell glob. Add
+`--dry-run` to preview deletions without performing them.
+
+Because deletion uses standard Git, this works with any remote (GitHub, GitLab,
+Bitbucket, self-hosted), not only GitHub.
+
 ## 📥 Installation
 
 ### As a standalone binary
@@ -269,6 +294,9 @@ fully-configured [example in the Vortex project](https://github.com/drevops/vort
 |----------------------------|---------------------|---------------------------------------------------------------------------------------------------------------------|
 | `--ansi`                   |                     | Force ANSI output. Use `--no-ansi` to disable                                                                       |
 | `--branch`                 | `[branch]`          | Destination branch with optional tokens (see below)                                                                 |
+| `--cleanup-age`            | `7`                 | Age in days after which a matching remote branch is considered stale; used with `--cleanup-stale`                    |
+| `--cleanup-pattern`        |                     | Glob pattern of remote branches eligible for stale cleanup (e.g. `deployment/*`); required with `--cleanup-stale`    |
+| `--cleanup-stale`          |                     | Delete stale remote branches that match `--cleanup-pattern` and are older than `--cleanup-age` days                  |
 | `--dry-run`                |                     | Run without pushing to the remote repository                                                                        |
 | `--fail-on-missing-branch` |                     | Fail artifact packaging if source branch cannot be determined. By default, artifact packaging is skipped gracefully |
 | `--gitignore`              |                     | Path to the `.gitignore` file to replace the current `.gitignore`                                                   |

--- a/src/Commands/ArtifactCommand.php
+++ b/src/Commands/ArtifactCommand.php
@@ -32,6 +32,8 @@ class ArtifactCommand extends Command {
 
   const MODE_FORCE_PUSH = 'force-push';
 
+  const CLEANUP_STALE_AGE_DEFAULT = 7;
+
   /**
    * Current Git repository.
    */
@@ -125,6 +127,21 @@ class ArtifactCommand extends Command {
   protected bool $pushSuccessful = FALSE;
 
   /**
+   * Flag to enable deletion of stale branches in the remote repository.
+   */
+  protected bool $cleanupStale = FALSE;
+
+  /**
+   * Glob pattern of remote branches eligible for stale cleanup.
+   */
+  protected string $cleanupPattern = '';
+
+  /**
+   * Age in days after which a matching remote branch is considered stale.
+   */
+  protected int $cleanupAge = self::CLEANUP_STALE_AGE_DEFAULT;
+
+  /**
    * Internal option to set current timestamp.
    */
   protected int $now;
@@ -175,7 +192,10 @@ class ArtifactCommand extends Command {
       ->addOption('root',                   NULL, InputOption::VALUE_REQUIRED, 'Path to the root for file path resolution. If not specified, current directory is used.')
       ->addOption('show-changes',           NULL, InputOption::VALUE_NONE,     'Show changes made to the repo during packaging in the output.')
       ->addOption('src',                    NULL, InputOption::VALUE_REQUIRED, 'Directory where source repository is located. If not specified, root directory is used.')
-      ->addOption('fail-on-missing-branch', NULL, InputOption::VALUE_NONE,     'Fail artifact packaging if source branch cannot be determined. By default, artifact packaging is skipped gracefully.');
+      ->addOption('fail-on-missing-branch', NULL, InputOption::VALUE_NONE,     'Fail artifact packaging if source branch cannot be determined. By default, artifact packaging is skipped gracefully.')
+      ->addOption('cleanup-stale',          NULL, InputOption::VALUE_NONE,     'Delete stale branches in the remote repository that match --cleanup-pattern and are older than --cleanup-age days.')
+      ->addOption('cleanup-pattern',        NULL, InputOption::VALUE_REQUIRED, 'Glob pattern of remote branches eligible for stale cleanup (e.g. "deployment/*"). Required when --cleanup-stale is set.')
+      ->addOption('cleanup-age',            NULL, InputOption::VALUE_REQUIRED, 'Age in days after which a matching remote branch is considered stale.', (string) self::CLEANUP_STALE_AGE_DEFAULT);
     // @formatter:on
     // phpcs:enable Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma
     // phpcs:enable Drupal.WhiteSpace.Comma.TooManySpaces
@@ -275,6 +295,8 @@ class ArtifactCommand extends Command {
 
         $this->output->writeln(sprintf('<info>Pushed branch "%s" with commit message "%s"</info>', $this->destinationBranch, $this->commitMessage));
       }
+
+      $this->cleanupStaleBranches();
     }
     catch (GitException $exception) {
       $result = $exception->getRunnerResult();
@@ -319,6 +341,65 @@ class ArtifactCommand extends Command {
   }
 
   /**
+   * Delete stale branches in the remote repository.
+   *
+   * Eligible branches are those matching the configured pattern whose tip commit
+   * is older than the configured age. The branch that was just pushed and the
+   * remote's default branch are always preserved. Cleanup is best-effort: any
+   * failure is logged and never fails the deployment, which has already
+   * succeeded by this point.
+   */
+  protected function cleanupStaleBranches(): void {
+    if (!$this->cleanupStale) {
+      return;
+    }
+
+    try {
+      $branches = $this->repo->getRemoteBranchesInfo($this->remoteName);
+    }
+    catch (GitException $exception) {
+      $this->output->writeln('<comment>Unable to list remote branches for cleanup.</comment>');
+      $this->logger->warning('Unable to list remote branches for cleanup: ' . $exception->getMessage());
+
+      return;
+    }
+
+    $protected_branches = [$this->destinationBranch];
+    $default_branch = $this->repo->getRemoteDefaultBranch($this->remoteName);
+    if ($default_branch !== NULL) {
+      $protected_branches[] = $default_branch;
+    }
+
+    $stale = ArtifactGitRepository::filterStaleBranches($branches, $this->cleanupPattern, $this->cleanupAge * 86400, $this->now, $protected_branches);
+
+    if ($stale === []) {
+      $this->output->writeln('<info>No stale branches to clean up.</info>');
+      $this->logger->notice('No stale branches to clean up.');
+
+      return;
+    }
+
+    foreach ($stale as $branch) {
+      if ($this->isDryRun) {
+        $this->output->writeln(sprintf('<info>Would delete stale branch "%s"</info>', $branch));
+        $this->logger->notice(sprintf('Would delete stale branch "%s"', $branch));
+
+        continue;
+      }
+
+      try {
+        $this->repo->deleteRemoteBranch($this->remoteName, $branch);
+        $this->output->writeln(sprintf('<info>Deleted stale branch "%s"</info>', $branch));
+        $this->logger->notice(sprintf('Deleted stale branch "%s"', $branch));
+      }
+      catch (GitException $exception) {
+        $this->output->writeln(sprintf('<comment>Failed to delete stale branch "%s"</comment>', $branch));
+        $this->logger->warning(sprintf('Failed to delete stale branch "%s": %s', $branch, $exception->getMessage()));
+      }
+    }
+  }
+
+  /**
    * Resolve and validate CLI options values into internal values.
    *
    * @param string $url
@@ -339,6 +420,21 @@ class ArtifactCommand extends Command {
     $this->isDryRun = !empty($options['dry-run']);
     $this->failOnMissingBranch = !empty($options['fail-on-missing-branch']);
     $this->logFile = empty($options['log']) || !is_string($options['log']) ? '' : $this->fsGetAbsolutePath($options['log']);
+
+    $this->cleanupStale = !empty($options['cleanup-stale']);
+    if ($this->cleanupStale) {
+      $pattern = isset($options['cleanup-pattern']) && is_string($options['cleanup-pattern']) ? trim($options['cleanup-pattern']) : '';
+      if ($pattern === '') {
+        throw new \RuntimeException('The --cleanup-pattern option is required when --cleanup-stale is set.');
+      }
+      $this->cleanupPattern = $pattern;
+
+      $age = $options['cleanup-age'] ?? NULL;
+      if (!is_numeric($age) || (float) $age != (int) $age || (int) $age < 1) {
+        throw new \RuntimeException('The --cleanup-age option must be a positive integer number of days.');
+      }
+      $this->cleanupAge = (int) $age;
+    }
 
     $this->setMode(is_string($options['mode']) ? $options['mode'] : '', $options);
 
@@ -415,6 +511,9 @@ class ArtifactCommand extends Command {
     $lines[] = (' Remote branch:         ' . $this->destinationBranch);
     $lines[] = (' Gitignore file:        ' . ($this->gitignoreFile ?: 'No'));
     $lines[] = (' Will push:             ' . ($this->isDryRun ? 'No' : 'Yes'));
+    if ($this->cleanupStale) {
+      $lines[] = (' Cleanup stale:         ' . sprintf('Yes (pattern "%s", older than %d days)', $this->cleanupPattern, $this->cleanupAge));
+    }
     $lines[] = ('----------------------------------------------------------------------');
 
     $this->output->writeln($lines);

--- a/src/Commands/ArtifactCommand.php
+++ b/src/Commands/ArtifactCommand.php
@@ -343,11 +343,11 @@ class ArtifactCommand extends Command {
   /**
    * Delete stale branches in the remote repository.
    *
-   * Eligible branches are those matching the configured pattern whose tip commit
-   * is older than the configured age. The branch that was just pushed and the
-   * remote's default branch are always preserved. Cleanup is best-effort: any
-   * failure is logged and never fails the deployment, which has already
-   * succeeded by this point.
+   * Eligible branches are those matching the configured pattern whose tip
+   * commit is older than the configured age. The branch that was just pushed
+   * and the remote's default branch are always preserved. Cleanup is
+   * best-effort: any failure is logged and never fails the deployment, which
+   * has already succeeded by this point.
    */
   protected function cleanupStaleBranches(): void {
     if (!$this->cleanupStale) {

--- a/src/Commands/ArtifactCommand.php
+++ b/src/Commands/ArtifactCommand.php
@@ -364,11 +364,15 @@ class ArtifactCommand extends Command {
       return;
     }
 
-    $protected_branches = [$this->destinationBranch];
     $default_branch = $this->repo->getRemoteDefaultBranch($this->remoteName);
-    if ($default_branch !== NULL) {
-      $protected_branches[] = $default_branch;
+    if ($default_branch === NULL) {
+      $this->output->writeln('<comment>Unable to determine the remote default branch; skipping stale cleanup for safety.</comment>');
+      $this->logger->warning('Unable to determine the remote default branch; skipping stale cleanup for safety.');
+
+      return;
     }
+
+    $protected_branches = [$this->destinationBranch, $default_branch];
 
     $stale = ArtifactGitRepository::filterStaleBranches($branches, $this->cleanupPattern, $this->cleanupAge * 86400, $this->now, $protected_branches);
 

--- a/src/Git/ArtifactGitRepository.php
+++ b/src/Git/ArtifactGitRepository.php
@@ -218,6 +218,85 @@ class ArtifactGitRepository extends GitRepository {
   }
 
   /**
+   * Get remote branches with their tip commit timestamps.
+   *
+   * A shallow fetch populates the remote-tracking refs; only the tip commit
+   * metadata is required to determine branch age, so the fetch is limited to a
+   * depth of one.
+   *
+   * @param string $remote
+   *   Remote name.
+   *
+   * @return array<string, int>
+   *   Branch names keyed to the Unix timestamp of their tip commit.
+   */
+  public function getRemoteBranchesInfo(string $remote): array {
+    $this->run('fetch', '--depth=1', $remote);
+
+    $lines = $this->extractFromCommand(['for-each-ref', '--format=%(refname:lstrip=3)|%(committerdate:unix)', 'refs/remotes/' . $remote]) ?: [];
+
+    $branches = [];
+    foreach ($lines as $line) {
+      if (!str_contains($line, '|')) {
+        continue;
+      }
+
+      [$name, $timestamp] = explode('|', $line, 2);
+
+      if ($name === '' || $name === 'HEAD' || !is_numeric($timestamp)) {
+        continue;
+      }
+
+      $branches[$name] = (int) $timestamp;
+    }
+
+    return $branches;
+  }
+
+  /**
+   * Get the default branch of a remote.
+   *
+   * @param string $remote
+   *   Remote name.
+   *
+   * @return string|null
+   *   The default branch name, or NULL if it cannot be determined.
+   */
+  public function getRemoteDefaultBranch(string $remote): ?string {
+    try {
+      $lines = $this->extractFromCommand(['ls-remote', '--symref', $remote, 'HEAD']) ?: [];
+    }
+    catch (GitException) {
+      return NULL;
+    }
+
+    foreach ($lines as $line) {
+      if (preg_match('#^ref:\s+refs/heads/(\S+)\s+HEAD#', $line, $matches)) {
+        return $matches[1];
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Delete a branch in the remote repository.
+   *
+   * @param string $remote
+   *   Remote name.
+   * @param string $branch
+   *   Branch name to delete.
+   *
+   * @return static
+   *   The git repository.
+   */
+  public function deleteRemoteBranch(string $remote, string $branch): static {
+    $this->run('push', $remote, '--delete', $branch);
+
+    return $this;
+  }
+
+  /**
    * Get tag pointing to HEAD.
    *
    * @return string[]
@@ -431,6 +510,49 @@ class ArtifactGitRepository extends GitRepository {
       'external' => $is_external,
       default => throw new \InvalidArgumentException(sprintf('Invalid argument "%s" provided', $type)),
     };
+  }
+
+  /**
+   * Filter branches down to those eligible for stale cleanup.
+   *
+   * @param array<string, int> $branches
+   *   Branch names keyed to the Unix timestamp of their tip commit.
+   * @param string $pattern
+   *   Glob pattern; only branches matching it are eligible.
+   * @param int $max_age
+   *   Maximum allowed age in seconds; branches older than this are stale.
+   * @param int $now
+   *   Reference "current" Unix timestamp to measure age against.
+   * @param array<string> $protected_branches
+   *   Branch names that must never be returned.
+   *
+   * @return array<string>
+   *   Names of stale branches, sorted for deterministic output.
+   */
+  public static function filterStaleBranches(array $branches, string $pattern, int $max_age, int $now, array $protected_branches = []): array {
+    $stale = [];
+
+    foreach ($branches as $name => $timestamp) {
+      $name = (string) $name;
+
+      if (in_array($name, $protected_branches, TRUE)) {
+        continue;
+      }
+
+      if (!fnmatch($pattern, $name)) {
+        continue;
+      }
+
+      if (($now - $timestamp) <= $max_age) {
+        continue;
+      }
+
+      $stale[] = $name;
+    }
+
+    sort($stale);
+
+    return $stale;
   }
 
   /**

--- a/src/Git/ArtifactGitRepository.php
+++ b/src/Git/ArtifactGitRepository.php
@@ -233,7 +233,8 @@ class ArtifactGitRepository extends GitRepository {
   public function getRemoteBranchesInfo(string $remote): array {
     $this->run('fetch', '--depth=1', $remote);
 
-    $lines = $this->extractFromCommand(['for-each-ref', '--format=%(refname:lstrip=3)|%(committerdate:unix)', 'refs/remotes/' . $remote]) ?: [];
+    $format = '%(refname:lstrip=3)|%(committerdate:unix)';
+    $lines = $this->extractFromCommand(['for-each-ref', '--format=' . $format, 'refs/remotes/' . $remote]) ?: [];
 
     $branches = [];
     foreach ($lines as $line) {
@@ -539,7 +540,7 @@ class ArtifactGitRepository extends GitRepository {
         continue;
       }
 
-      if (!fnmatch($pattern, $name)) {
+      if (!self::matchesGlob($pattern, $name)) {
         continue;
       }
 
@@ -553,6 +554,26 @@ class ArtifactGitRepository extends GitRepository {
     sort($stale);
 
     return $stale;
+  }
+
+  /**
+   * Test whether a branch name matches a shell-style glob pattern.
+   *
+   * Converts the glob into a regular expression so the match honours the
+   * same '*' and '?' semantics as a shell glob without using fnmatch().
+   *
+   * @param string $pattern
+   *   The glob pattern to match against (e.g. 'deployment/*').
+   * @param string $subject
+   *   The string to test.
+   *
+   * @return bool
+   *   TRUE when the subject matches the pattern.
+   */
+  protected static function matchesGlob(string $pattern, string $subject): bool {
+    $regex = '/^' . str_replace(['\*', '\?'], ['.*', '.'], preg_quote($pattern, '/')) . '$/';
+
+    return (bool) preg_match($regex, $subject);
   }
 
   /**

--- a/tests/Functional/CleanupStaleBranchesTest.php
+++ b/tests/Functional/CleanupStaleBranchesTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\GitArtifact\Tests\Functional;
+
+use DrevOps\GitArtifact\Commands\ArtifactCommand;
+use DrevOps\GitArtifact\Git\ArtifactGitRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(ArtifactCommand::class)]
+#[CoversClass(ArtifactGitRepository::class)]
+class CleanupStaleBranchesTest extends FunctionalTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    $this->mode = ArtifactCommand::MODE_BRANCH;
+    parent::setUp();
+  }
+
+  public function testPrunesStaleBranches(): void {
+    $this->gitCommitFileWithDate($this->dst, 'init', $this->now - 86400, 'Initial');
+    $this->gitCreateBranchWithCommitDate($this->dst, 'deployment/old1', $this->now - 10 * 86400);
+    $this->gitCreateBranchWithCommitDate($this->dst, 'deployment/old2', $this->now - 4 * 86400);
+    $this->gitCreateBranchWithCommitDate($this->dst, 'deployment/fresh', $this->now - 86400);
+    $this->gitCreateBranchWithCommitDate($this->dst, 'feature/keep', $this->now - 10 * 86400);
+    $this->gitCheckout($this->dst, $this->currentBranch);
+
+    $this->gitCreateFixtureCommits(2);
+
+    $output = $this->assertArtifactCommandSuccess([
+      '--cleanup-stale' => TRUE,
+      '--cleanup-pattern' => 'deployment/*',
+      '--cleanup-age' => '3',
+    ]);
+
+    $this->assertStringContainsString('Cleanup stale:         Yes (pattern "deployment/*", older than 3 days)', $output);
+    $this->assertStringContainsString('Deleted stale branch "deployment/old1"', $output);
+    $this->assertStringContainsString('Deleted stale branch "deployment/old2"', $output);
+
+    $this->gitAssertBranchesNotExist($this->dst, ['deployment/old1', 'deployment/old2']);
+    $this->gitAssertBranchesExist($this->dst, ['deployment/fresh', 'feature/keep', 'testbranch', $this->currentBranch]);
+  }
+
+  public function testDryRunDoesNotPrune(): void {
+    $this->gitCommitFileWithDate($this->dst, 'init', $this->now - 86400, 'Initial');
+    $this->gitCreateBranchWithCommitDate($this->dst, 'deployment/old', $this->now - 10 * 86400);
+    $this->gitCheckout($this->dst, $this->currentBranch);
+
+    $this->gitCreateFixtureCommits(2);
+
+    $output = $this->runArtifactCommand([
+      '--cleanup-stale' => TRUE,
+      '--cleanup-pattern' => 'deployment/*',
+      '--cleanup-age' => '3',
+      '--dry-run' => TRUE,
+      '--branch' => 'testbranch',
+    ]);
+
+    $this->assertStringContainsString('Would delete stale branch "deployment/old"', $output);
+    $this->assertStringNotContainsString('Deleted stale branch', $output);
+    $this->gitAssertBranchesExist($this->dst, ['deployment/old']);
+  }
+
+  public function testProtectsDefaultAndPushedBranches(): void {
+    $this->gitCommitFileWithDate($this->dst, 'init', $this->now - 100 * 86400, 'Initial');
+    $this->gitCreateBranchWithCommitDate($this->dst, 'deployment/old', $this->now - 100 * 86400);
+    $this->gitCheckout($this->dst, $this->currentBranch);
+
+    $this->gitCreateFixtureCommits(2);
+
+    $output = $this->assertArtifactCommandSuccess([
+      '--cleanup-stale' => TRUE,
+      '--cleanup-pattern' => '*',
+      '--cleanup-age' => '3',
+    ]);
+
+    $this->assertStringContainsString('Deleted stale branch "deployment/old"', $output);
+    $this->gitAssertBranchesNotExist($this->dst, ['deployment/old']);
+    // Both the just-pushed branch and the remote default branch match the "*"
+    // pattern and are old enough to be stale, but are always preserved.
+    $this->gitAssertBranchesExist($this->dst, ['testbranch', $this->currentBranch]);
+  }
+
+  public function testNoStaleBranches(): void {
+    $this->gitCommitFileWithDate($this->dst, 'init', $this->now - 86400, 'Initial');
+    $this->gitCreateBranchWithCommitDate($this->dst, 'deployment/fresh', $this->now - 86400);
+    $this->gitCheckout($this->dst, $this->currentBranch);
+
+    $this->gitCreateFixtureCommits(2);
+
+    $output = $this->assertArtifactCommandSuccess([
+      '--cleanup-stale' => TRUE,
+      '--cleanup-pattern' => 'deployment/*',
+      '--cleanup-age' => '3',
+    ]);
+
+    $this->assertStringContainsString('No stale branches to clean up.', $output);
+    $this->gitAssertBranchesExist($this->dst, ['deployment/fresh']);
+  }
+
+  public function testRemoteDefaultBranchUnknownRemoteReturnsNull(): void {
+    $repo = new ArtifactGitRepository($this->src);
+
+    $this->assertNull($repo->getRemoteDefaultBranch('does-not-exist'));
+  }
+
+  public function testRequiresPattern(): void {
+    $this->gitCreateFixtureCommits(2);
+
+    $output = $this->runArtifactCommand([
+      '--cleanup-stale' => TRUE,
+      '--branch' => 'testbranch',
+    ], TRUE);
+
+    $this->assertStringContainsString('The --cleanup-pattern option is required when --cleanup-stale is set.', $output);
+  }
+
+  #[DataProvider('dataProviderRejectsInvalidAge')]
+  public function testRejectsInvalidAge(string $age): void {
+    $this->gitCreateFixtureCommits(2);
+
+    $output = $this->runArtifactCommand([
+      '--cleanup-stale' => TRUE,
+      '--cleanup-pattern' => 'deployment/*',
+      '--cleanup-age' => $age,
+      '--branch' => 'testbranch',
+    ], TRUE);
+
+    $this->assertStringContainsString('The --cleanup-age option must be a positive integer number of days.', $output);
+  }
+
+  /**
+   * @return array<string, array<string>>
+   *   Test data.
+   */
+  public static function dataProviderRejectsInvalidAge(): array {
+    return [
+      'zero' => ['0'],
+      'negative' => ['-1'],
+      'non-numeric' => ['abc'],
+      'fractional' => ['3.5'],
+    ];
+  }
+
+}

--- a/tests/Functional/CleanupStaleBranchesTest.php
+++ b/tests/Functional/CleanupStaleBranchesTest.php
@@ -80,8 +80,8 @@ class CleanupStaleBranchesTest extends FunctionalTestCase {
 
     $this->assertStringContainsString('Deleted stale branch "deployment/old"', $output);
     $this->gitAssertBranchesNotExist($this->dst, ['deployment/old']);
-    // Both the just-pushed branch and the remote default branch match the "*"
-    // pattern and are old enough to be stale, but are always preserved.
+    // The just-pushed branch (fresh) and the remote default branch (stale) both
+    // match the "*" pattern but are always preserved regardless of their age.
     $this->gitAssertBranchesExist($this->dst, ['testbranch', $this->currentBranch]);
   }
 

--- a/tests/Traits/GitTrait.php
+++ b/tests/Traits/GitTrait.php
@@ -382,7 +382,7 @@ trait GitTrait {
   protected function gitCreateBranchWithCommitDate(string $path, string $branch, int $timestamp): void {
     (new Git())->open($path)->createBranch($branch, TRUE);
 
-    $filename = 'file_' . (string) preg_replace('/[^a-z0-9]+/i', '_', $branch);
+    $filename = 'file_' . preg_replace('/[^a-z0-9]+/i', '_', $branch);
     $this->gitCommitFileWithDate($path, $filename, $timestamp, 'Commit for ' . $branch);
   }
 

--- a/tests/Traits/GitTrait.php
+++ b/tests/Traits/GitTrait.php
@@ -356,6 +356,9 @@ trait GitTrait {
   protected function gitCommitFileWithDate(string $path, string $filename, int $timestamp, string $message): void {
     (new Filesystem())->dumpFile($path . DIRECTORY_SEPARATOR . $filename, $filename);
 
+    $previous_author_date = getenv('GIT_AUTHOR_DATE');
+    $previous_committer_date = getenv('GIT_COMMITTER_DATE');
+
     $date = date('c', $timestamp);
     putenv('GIT_AUTHOR_DATE=' . $date);
     putenv('GIT_COMMITTER_DATE=' . $date);
@@ -364,8 +367,8 @@ trait GitTrait {
       (new Git())->open($path)->addFile($filename)->commit($message);
     }
     finally {
-      putenv('GIT_AUTHOR_DATE');
-      putenv('GIT_COMMITTER_DATE');
+      putenv($previous_author_date === FALSE ? 'GIT_AUTHOR_DATE' : 'GIT_AUTHOR_DATE=' . $previous_author_date);
+      putenv($previous_committer_date === FALSE ? 'GIT_COMMITTER_DATE' : 'GIT_COMMITTER_DATE=' . $previous_committer_date);
     }
   }
 

--- a/tests/Traits/GitTrait.php
+++ b/tests/Traits/GitTrait.php
@@ -342,6 +342,98 @@ trait GitTrait {
   }
 
   /**
+   * Commit a new file on the current branch with a specific commit date.
+   *
+   * @param string $path
+   *   Path to the repository.
+   * @param string $filename
+   *   Name of the file to create and commit.
+   * @param int $timestamp
+   *   Unix timestamp to use for both author and committer dates.
+   * @param string $message
+   *   Commit message.
+   */
+  protected function gitCommitFileWithDate(string $path, string $filename, int $timestamp, string $message): void {
+    (new Filesystem())->dumpFile($path . DIRECTORY_SEPARATOR . $filename, $filename);
+
+    $date = date('c', $timestamp);
+    putenv('GIT_AUTHOR_DATE=' . $date);
+    putenv('GIT_COMMITTER_DATE=' . $date);
+
+    try {
+      (new Git())->open($path)->addFile($filename)->commit($message);
+    }
+    finally {
+      putenv('GIT_AUTHOR_DATE');
+      putenv('GIT_COMMITTER_DATE');
+    }
+  }
+
+  /**
+   * Create a branch with a single commit dated at a given time.
+   *
+   * @param string $path
+   *   Path to the repository.
+   * @param string $branch
+   *   Branch name to create and check out.
+   * @param int $timestamp
+   *   Unix timestamp to use for the commit author and committer dates.
+   */
+  protected function gitCreateBranchWithCommitDate(string $path, string $branch, int $timestamp): void {
+    (new Git())->open($path)->createBranch($branch, TRUE);
+
+    $filename = 'file_' . (string) preg_replace('/[^a-z0-9]+/i', '_', $branch);
+    $this->gitCommitFileWithDate($path, $filename, $timestamp, 'Commit for ' . $branch);
+  }
+
+  /**
+   * Get the list of local branch names in a repository.
+   *
+   * @param string $path
+   *   Path to the repository.
+   *
+   * @return array<string>
+   *   Branch names with any decoration removed.
+   */
+  protected function gitGetBranchList(string $path): array {
+    $branches = (new Git())->open($path)->getBranches() ?: [];
+
+    return array_map(static fn(string $branch): string => trim(ltrim($branch, '* ')), $branches);
+  }
+
+  /**
+   * Assert that branches exist in a repository.
+   *
+   * @param string $path
+   *   Path to the repository.
+   * @param array<string> $branches
+   *   Branch names to assert as present.
+   */
+  protected function gitAssertBranchesExist(string $path, array $branches): void {
+    $existing = $this->gitGetBranchList($path);
+
+    foreach ($branches as $branch) {
+      $this->assertContains($branch, $existing, sprintf('Branch "%s" exists', $branch));
+    }
+  }
+
+  /**
+   * Assert that branches do not exist in a repository.
+   *
+   * @param string $path
+   *   Path to the repository.
+   * @param array<string> $branches
+   *   Branch names to assert as absent.
+   */
+  protected function gitAssertBranchesNotExist(string $path, array $branches): void {
+    $existing = $this->gitGetBranchList($path);
+
+    foreach ($branches as $branch) {
+      $this->assertNotContains($branch, $existing, sprintf('Branch "%s" does not exist', $branch));
+    }
+  }
+
+  /**
    * Get global default branch.
    *
    * @return string

--- a/tests/Unit/ArtifactCommandTest.php
+++ b/tests/Unit/ArtifactCommandTest.php
@@ -32,7 +32,7 @@ class ArtifactCommandTest extends UnitTestCase {
   public function testCleanupStaleBranchesHandlesDeleteFailure(): void {
     $repo = $this->prepareMock(ArtifactGitRepository::class, [
       'getRemoteBranchesInfo' => fn(): array => ['deployment/old' => 1000],
-      'getRemoteDefaultBranch' => fn(): ?string => NULL,
+      'getRemoteDefaultBranch' => fn(): string => 'main',
       'deleteRemoteBranch' => fn(): never => throw new GitException('boom'),
     ], FALSE);
 
@@ -42,6 +42,20 @@ class ArtifactCommandTest extends UnitTestCase {
     $this->callProtectedMethod($command, 'cleanupStaleBranches');
 
     $this->assertStringContainsString('Failed to delete stale branch "deployment/old"', $output->fetch());
+  }
+
+  public function testCleanupStaleBranchesSkipsWhenDefaultBranchUnknown(): void {
+    $repo = $this->prepareMock(ArtifactGitRepository::class, [
+      'getRemoteBranchesInfo' => fn(): array => ['deployment/old' => 1000],
+      'getRemoteDefaultBranch' => fn(): ?string => NULL,
+    ], FALSE);
+
+    $output = new BufferedOutput();
+    $command = $this->createCleanupCommand($repo, $output);
+
+    $this->callProtectedMethod($command, 'cleanupStaleBranches');
+
+    $this->assertStringContainsString('Unable to determine the remote default branch', $output->fetch());
   }
 
   /**

--- a/tests/Unit/ArtifactCommandTest.php
+++ b/tests/Unit/ArtifactCommandTest.php
@@ -31,8 +31,8 @@ class ArtifactCommandTest extends UnitTestCase {
 
   public function testCleanupStaleBranchesHandlesDeleteFailure(): void {
     $repo = $this->prepareMock(ArtifactGitRepository::class, [
-      'getRemoteBranchesInfo' => ['deployment/old' => 1000],
-      'getRemoteDefaultBranch' => NULL,
+      'getRemoteBranchesInfo' => fn(): array => ['deployment/old' => 1000],
+      'getRemoteDefaultBranch' => fn(): ?string => NULL,
       'deleteRemoteBranch' => fn(): never => throw new GitException('boom'),
     ], FALSE);
 
@@ -46,6 +46,10 @@ class ArtifactCommandTest extends UnitTestCase {
 
   /**
    * Build a command instance wired for cleanupStaleBranches() in isolation.
+   *
+   * The command's collaborators are normally populated by execute(); here they
+   * are injected directly via reflection so cleanupStaleBranches() can be
+   * exercised on its own, without bootstrapping the full command run.
    *
    * @param \PHPUnit\Framework\MockObject\MockObject $repo
    *   Repository mock to operate on.

--- a/tests/Unit/ArtifactCommandTest.php
+++ b/tests/Unit/ArtifactCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\GitArtifact\Tests\Unit;
+
+use CzProject\GitPhp\GitException;
+use DrevOps\GitArtifact\Commands\ArtifactCommand;
+use DrevOps\GitArtifact\Git\ArtifactGitRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[CoversClass(ArtifactCommand::class)]
+#[CoversClass(ArtifactGitRepository::class)]
+class ArtifactCommandTest extends UnitTestCase {
+
+  public function testCleanupStaleBranchesHandlesListFailure(): void {
+    $repo = $this->prepareMock(ArtifactGitRepository::class, [
+      'getRemoteBranchesInfo' => fn(): never => throw new GitException('boom'),
+    ], FALSE);
+
+    $output = new BufferedOutput();
+    $command = $this->createCleanupCommand($repo, $output);
+
+    $this->callProtectedMethod($command, 'cleanupStaleBranches');
+
+    $this->assertStringContainsString('Unable to list remote branches for cleanup.', $output->fetch());
+  }
+
+  public function testCleanupStaleBranchesHandlesDeleteFailure(): void {
+    $repo = $this->prepareMock(ArtifactGitRepository::class, [
+      'getRemoteBranchesInfo' => ['deployment/old' => 1000],
+      'getRemoteDefaultBranch' => NULL,
+      'deleteRemoteBranch' => fn(): never => throw new GitException('boom'),
+    ], FALSE);
+
+    $output = new BufferedOutput();
+    $command = $this->createCleanupCommand($repo, $output);
+
+    $this->callProtectedMethod($command, 'cleanupStaleBranches');
+
+    $this->assertStringContainsString('Failed to delete stale branch "deployment/old"', $output->fetch());
+  }
+
+  /**
+   * Build a command instance wired for cleanupStaleBranches() in isolation.
+   *
+   * @param \PHPUnit\Framework\MockObject\MockObject $repo
+   *   Repository mock to operate on.
+   * @param \Symfony\Component\Console\Output\BufferedOutput $output
+   *   Output buffer to capture messages.
+   *
+   * @return \DrevOps\GitArtifact\Commands\ArtifactCommand
+   *   Configured command instance.
+   */
+  protected function createCleanupCommand(MockObject $repo, BufferedOutput $output): ArtifactCommand {
+    $command = new ArtifactCommand();
+
+    $this->setProtectedValue($command, 'repo', $repo);
+    $this->setProtectedValue($command, 'cleanupStale', TRUE);
+    $this->setProtectedValue($command, 'cleanupPattern', '*');
+    $this->setProtectedValue($command, 'cleanupAge', 3);
+    $this->setProtectedValue($command, 'now', 100000000);
+    $this->setProtectedValue($command, 'remoteName', 'dst');
+    $this->setProtectedValue($command, 'destinationBranch', 'main');
+    $this->setProtectedValue($command, 'isDryRun', FALSE);
+    $this->setProtectedValue($command, 'output', $output);
+    $this->setProtectedValue($command, 'logger', new NullLogger());
+
+    return $command;
+  }
+
+}

--- a/tests/Unit/ArtifactGitRepositoryTest.php
+++ b/tests/Unit/ArtifactGitRepositoryTest.php
@@ -122,4 +122,46 @@ class ArtifactGitRepositoryTest extends UnitTestCase {
     ];
   }
 
+  /**
+   * @param array<string, int> $branches
+   *   Branches keyed to tip timestamps.
+   * @param array<string> $protected_branches
+   *   Protected branch names.
+   * @param array<string> $expected
+   *   Expected stale branch names.
+   */
+  #[DataProvider('dataProviderFilterStaleBranches')]
+  public function testFilterStaleBranches(array $branches, string $pattern, int $max_age, int $now, array $protected_branches, array $expected): void {
+    $this->assertSame($expected, ArtifactGitRepository::filterStaleBranches($branches, $pattern, $max_age, $now, $protected_branches));
+  }
+
+  /**
+   * @return array<string, mixed>
+   *   Test data.
+   */
+  public static function dataProviderFilterStaleBranches(): array {
+    $now = 1000000000;
+    $day = 86400;
+
+    return [
+      'empty' => [[], '*', 3 * $day, $now, [], []],
+      'no pattern match' => [['feature/x' => $now - 10 * $day], 'deployment/*', 3 * $day, $now, [], []],
+      'stale match' => [['deployment/a' => $now - 10 * $day], 'deployment/*', 3 * $day, $now, [], ['deployment/a']],
+      'fresh kept' => [['deployment/a' => $now - $day], 'deployment/*', 3 * $day, $now, [], []],
+      'boundary equal kept' => [['deployment/a' => $now - 3 * $day], 'deployment/*', 3 * $day, $now, [], []],
+      'boundary just over' => [['deployment/a' => $now - 3 * $day - 1], 'deployment/*', 3 * $day, $now, [], ['deployment/a']],
+      'protected excluded' => [['deployment/a' => $now - 10 * $day], 'deployment/*', 3 * $day, $now, ['deployment/a'], []],
+      'future timestamp kept' => [['deployment/a' => $now + 5 * $day], 'deployment/*', 3 * $day, $now, [], []],
+      'sorted output' => [
+        ['deployment/c' => $now - 10 * $day, 'deployment/a' => $now - 10 * $day, 'deployment/b' => $now - 10 * $day],
+        'deployment/*', 3 * $day, $now, [], ['deployment/a', 'deployment/b', 'deployment/c'],
+      ],
+      'numeric branch name' => [['123' => $now - 10 * $day], '*', 3 * $day, $now, [], ['123']],
+      'wildcard all but protected' => [
+        ['a' => $now - 10 * $day, 'b' => $now - 10 * $day],
+        '*', 3 * $day, $now, ['b'], ['a'],
+      ],
+    ];
+  }
+
 }

--- a/tests/Unit/ArtifactGitRepositoryTest.php
+++ b/tests/Unit/ArtifactGitRepositoryTest.php
@@ -125,6 +125,12 @@ class ArtifactGitRepositoryTest extends UnitTestCase {
   /**
    * @param array<string, int> $branches
    *   Branches keyed to tip timestamps.
+   * @param string $pattern
+   *   Glob pattern to match eligible branches.
+   * @param int $max_age
+   *   Maximum allowed age in seconds.
+   * @param int $now
+   *   Reference Unix timestamp.
    * @param array<string> $protected_branches
    *   Protected branch names.
    * @param array<string> $expected


### PR DESCRIPTION
Closes #23

## Summary

Adds an opt-in `--cleanup-stale` flag to the `artifact` command that prunes stale branches from the destination repository after a successful push. A companion `--cleanup-pattern` glob (required) identifies which branches were created by the deployment workflow, and `--cleanup-age` (default 7 days) sets the staleness threshold. Cleanup is host-agnostic - it uses standard `git push --delete`, so it works with GitHub, GitLab, Bitbucket, and any other remote. The just-pushed branch and the remote's default branch are always protected, and cleanup fails closed: if the remote default branch cannot be resolved, pruning is skipped entirely rather than risk deleting it. Any fetch or delete failure is logged as a warning and never aborts the deployment.

## Changes

**New CLI options** (`src/Commands/ArtifactCommand.php`):
- `--cleanup-stale` - boolean gate that enables the feature; off by default so existing workflows are unaffected.
- `--cleanup-pattern` - required when `--cleanup-stale` is set; a shell glob identifying the deployment branches (e.g. `deployment/*`).
- `--cleanup-age` - positive integer number of days; branches older than this are eligible for deletion (default: 7).
- Validation at option-resolve time: a missing pattern or invalid age throws `RuntimeException` before any Git work begins.
- The summary banner printed at the start of a run shows the pattern and age when cleanup is enabled.
- `--dry-run` is respected: stale branches are listed but not deleted.
- Fail-closed safety: when the remote default branch cannot be determined, cleanup is skipped with a warning so the default branch can never be deleted.

**Repository layer** (`src/Git/ArtifactGitRepository.php`):
- `getRemoteBranchesInfo(string $remote): array<string, int>` - shallow-fetches the remote (`--depth=1`) then reads `refs/remotes/<remote>` via `for-each-ref` to return branch-name-to-Unix-timestamp pairs.
- `getRemoteDefaultBranch(string $remote): ?string` - resolves the remote's symbolic HEAD via `ls-remote --symref`; returns `null` on any failure.
- `deleteRemoteBranch(string $remote, string $branch): static` - runs `git push <remote> --delete <branch>`.
- `static filterStaleBranches(...)` - pure filtering logic: applies the glob, the age cutoff, and the protected-branch list, returning a sorted result. Static for easy unit-testing without a real repository.

**Tests**:
- `tests/Functional/CleanupStaleBranchesTest.php` - seven functional scenarios: basic prune, dry-run passthrough, default-and-just-pushed branch protection, no-stale-branches no-op, unknown-remote returns null, missing-pattern validation, and invalid-age validation (data provider).
- `tests/Unit/ArtifactCommandTest.php` - unit coverage for the three error-recovery paths in `cleanupStaleBranches()`: list failure, per-branch delete failure, and the fail-closed skip when the default branch is unknown.
- `tests/Unit/ArtifactGitRepositoryTest.php` - eleven data-provider cases for `filterStaleBranches()` covering empty input, glob non-match, staleness boundary, protected exclusion, future timestamps, sorted output, numeric branch names, and wildcard-with-protected.
- `tests/Traits/GitTrait.php` - new test helpers: `gitCommitFileWithDate()` (which now preserves and restores any pre-existing `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE`), `gitCreateBranchWithCommitDate()`, `gitGetBranchList()`, `gitAssertBranchesExist()`, `gitAssertBranchesNotExist()`.

**Documentation** (`README.md`):
- New "Cleanup of stale branches" subsection with a usage example and prose explanation.
- Three new rows in the CLI reference table for `--cleanup-age`, `--cleanup-pattern`, and `--cleanup-stale`.

## Before / After

```
BEFORE
──────────────────────────────────────────────────────────
  Destination repo after N deployments (branch mode):

  refs/heads/deployment/1.0.0   (90 days old)
  refs/heads/deployment/1.1.0   (60 days old)
  refs/heads/deployment/1.2.0   (30 days old)
  refs/heads/deployment/1.3.0   (3 days old)   <-- just pushed
  refs/heads/main

  Branches accumulate indefinitely; no automatic pruning.

AFTER (with --cleanup-stale --cleanup-pattern="deployment/*" --cleanup-age=7)
──────────────────────────────────────────────────────────
  Push succeeds as before, then cleanup runs:

    Deleted stale branch "deployment/1.0.0"
    Deleted stale branch "deployment/1.1.0"
    Deleted stale branch "deployment/1.2.0"

  Destination repo after cleanup:

  refs/heads/deployment/1.3.0   (just pushed - always protected)
  refs/heads/main                (default branch - always protected)

  Safety: if the default branch can't be resolved, cleanup is skipped.
  Any delete failure logs a warning; the deployment exit code is unaffected.
```
